### PR TITLE
Updated access and files after the November 2021 update

### DIFF
--- a/204622/T1w/T2w_acpc_dc.nii.gz
+++ b/204622/T1w/T2w_acpc_dc.nii.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/7G/W3/MD5E-s70654312--71ee271b65f580001d4ae9b098f278d0.nii.gz/MD5E-s70654312--71ee271b65f580001d4ae9b098f278d0.nii.gz

--- a/206828/T1w/T1w_acpc_dc_restore.nii.gz
+++ b/206828/T1w/T1w_acpc_dc_restore.nii.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/kX/Kx/MD5E-s71319902--3ad5f1fc69064237eb10e220b99ccb81.nii.gz/MD5E-s71319902--3ad5f1fc69064237eb10e220b99ccb81.nii.gz


### PR DESCRIPTION
After https://github.com/datalad-datasets/human-connectome-project-openaccess/pull/31 this PR updates this subset of the HCP dataset with two additional files and an updated submodule change. Availability updates are already pushed.